### PR TITLE
Implement a transaction router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@ xsc*
 dump.vcd
 sim.prj
 *.wdb
+*~
+*_string.go
+src/router/sw_axi/wire
+*_generated.h
+testbench
+go.sum
+router

--- a/src/common/IpcStructs.fbs
+++ b/src/common/IpcStructs.fbs
@@ -4,6 +4,7 @@ namespace sw_axi.wire;
 enum Type:byte {
   SYSTEM_INFO,
   IP_INFO,
+  IP_ACK,
   ACK,
   ERROR,
   COMMIT
@@ -25,17 +26,17 @@ enum ImplementationType:byte {
 
 table SystemInfo {
   name:string;
+  systemName:string;
   pid:ulong;
-  uri:string;
   hostname:string;
 }
 
 table IpInfo {
   name:string;
-  startAddr:ulong;
-  endAddr:ulong;
-  startInterrupt:uint;
-  endInterrupt:uint;
+  address:ulong;
+  size:ulong;
+  firstInterrupt:ushort;
+  numInterrupts:ushort;
   type:IpType;
   implementation:ImplementationType;
 }
@@ -44,6 +45,7 @@ table Message {
   type:Type;
   systemInfo:SystemInfo;
   ipInfo:IpInfo;
+  ipId:ulong;
   errorMessage:string;
 }
 

--- a/src/lib/SwAxi.cc
+++ b/src/lib/SwAxi.cc
@@ -312,7 +312,7 @@ int Bridge::start() {
     }
 
     if (msg->type() != wire::Type_ACK) {
-        LOG << "[SW-AXI] Got an unexpected response while receibing IP list: ";
+        LOG << "[SW-AXI] Got an unexpected response while receiving IP list: ";
         LOG << msg->type() << std::endl;
         disconnect();
         return -1;

--- a/src/router/go.mod
+++ b/src/router/go.mod
@@ -1,0 +1,13 @@
+module router
+
+require (
+	github.com/google/flatbuffers v1.12.0
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
+	github.com/sirupsen/logrus v1.7.0
+	github.com/x-cray/logrus-prefixed-formatter v0.5.2
+	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
+	golang.org/x/tools v0.0.0-20201103235415-b653051172e4 // indirect
+)
+
+go 1.13

--- a/src/router/main.go
+++ b/src/router/main.go
@@ -1,0 +1,78 @@
+//------------------------------------------------------------------------------
+// Copyright (C) 2020 Daedalean AG
+//
+// This file is part of SW-AXI.
+//
+// SW-AXI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SW-AXI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with SW-AXI.  If not, see <https://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+//go:generate flatc --go ../common/IpcStructs.fbs
+
+package main
+
+import (
+	"flag"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	prefixed "github.com/x-cray/logrus-prefixed-formatter"
+	"router/sw_axi"
+)
+
+func main() {
+	logFile := flag.String("log-file", "", "output file for diagnostics")
+	logLevel := flag.String("log-level", "Info", "verbosity of the diagnostic information")
+	numClients := flag.Int("n", 2, "number of clients")
+	uri := flag.String("uri", "unix:///tmp/sw-axi", "the rendez-vous point")
+
+	flag.Parse()
+
+	log.SetFormatter(&prefixed.TextFormatter{
+		TimestampFormat: "2006-01-02 15:04:05",
+		FullTimestamp:   true,
+		ForceFormatting: true,
+	})
+
+	if *logFile != "" {
+		f, err := os.OpenFile(*logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		log.SetOutput(f)
+	}
+
+	level := log.InfoLevel
+	if *logLevel != "" {
+		l, err := log.ParseLevel(*logLevel)
+		if err != nil {
+			log.Fatal(err)
+		}
+		level = l
+	}
+	log.SetLevel(level)
+
+	log.Info("Starting the SW-AXI router...")
+	log.Infof("Rendez-vous point: %s", *uri)
+	log.Infof("Number of clients: %d", *numClients)
+
+	router, err := sw_axi.NewRouter(*uri, *numClients)
+	if err != nil {
+		log.Fatalf("Can't create a router: %s", err)
+	}
+
+	if err := router.Run(); err != nil {
+		log.Fatalf("Can't run a listener: %s", err)
+	}
+}

--- a/src/router/sw_axi/client.go
+++ b/src/router/sw_axi/client.go
@@ -1,0 +1,287 @@
+//------------------------------------------------------------------------------
+// Copyright (C) 2020 Daedalean AG
+//
+// This file is part of SW-AXI.
+//
+// SW-AXI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SW-AXI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with SW-AXI.  If not, see <https://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+package sw_axi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+
+	flatbuffers "github.com/google/flatbuffers/go"
+	log "github.com/sirupsen/logrus"
+	"router/sw_axi/wire"
+)
+
+type client struct {
+	SystemInfo SystemInfo
+	wg         *sync.WaitGroup
+	conn       net.Conn
+}
+
+func (c *client) readMsg() ([]byte, error) {
+	sizeArr := make([]byte, 8)
+	if _, err := io.ReadFull(c.conn, sizeArr); err != nil {
+		return nil, fmt.Errorf("Unable to read message size: %s", err)
+	}
+	size := binary.LittleEndian.Uint64(sizeArr)
+
+	msg := make([]byte, size)
+	if _, err := io.ReadFull(c.conn, msg); err != nil {
+		return nil, fmt.Errorf("Unable to read message: %s", err)
+	}
+	return msg, nil
+}
+
+func (c *client) writeMsg(msg []byte) error {
+	sizeArr := make([]byte, 8)
+	binary.LittleEndian.PutUint64(sizeArr, uint64(len(msg)))
+	if _, err := io.Copy(c.conn, bytes.NewReader(sizeArr)); err != nil {
+		return fmt.Errorf("Unable to write message size: %s", err)
+	}
+
+	if _, err := io.Copy(c.conn, bytes.NewReader(msg)); err != nil {
+		return fmt.Errorf("Unable to write message: %s", err)
+	}
+	return nil
+}
+
+func (c *client) shakeHands() error {
+	msgArr, err := c.readMsg()
+	if err != nil {
+		return err
+	}
+
+	msg := wire.GetRootAsMessage(msgArr, 0)
+	if msg.Type() != wire.TypeSYSTEM_INFO {
+		return fmt.Errorf("Expected a SYSTEM_INFO message but got: %s", wire.EnumNamesType[msg.Type()])
+	}
+
+	si := msg.SystemInfo(nil)
+	c.SystemInfo = SystemInfo{string(si.Name()), string(si.SystemName()), string(si.Hostname()), si.Pid()}
+
+	hn, err := os.Hostname()
+	if err != nil {
+		log.Fatalf("Can't get hostname: %s", err)
+	}
+
+	builder := flatbuffers.NewBuilder(0)
+	router := builder.CreateString("router")
+	sysName := builder.CreateString(strings.ToUpper(runtime.GOOS[:1]) + runtime.GOOS[1:] + " Golang")
+	hName := builder.CreateString(hn)
+
+	wire.SystemInfoStart(builder)
+	wire.SystemInfoAddName(builder, router)
+	wire.SystemInfoAddSystemName(builder, sysName)
+	wire.SystemInfoAddHostname(builder, hName)
+	wire.SystemInfoAddPid(builder, uint64(os.Getpid()))
+	mySi := wire.SystemInfoEnd(builder)
+
+	wire.MessageStart(builder)
+	wire.MessageAddType(builder, wire.TypeSYSTEM_INFO)
+	wire.MessageAddSystemInfo(builder, mySi)
+	builder.Finish(wire.MessageEnd(builder))
+
+	rsp := builder.FinishedBytes()
+	return c.writeMsg(rsp)
+}
+
+func (c *client) receiveIpInfo() (*IpInfo, error) {
+	msgArr, err := c.readMsg()
+	if err != nil {
+		return nil, err
+	}
+
+	msg := wire.GetRootAsMessage(msgArr, 0)
+	if msg.Type() == wire.TypeCOMMIT {
+		return nil, nil
+	}
+
+	if msg.Type() != wire.TypeIP_INFO {
+		return nil, fmt.Errorf("Expected IP_INFO or COMMIT, got: %s", wire.EnumNamesType[msg.Type()])
+	}
+
+	ii := msg.IpInfo(nil)
+	var typ IpType
+	switch ii.Type() {
+	case wire.IpTypeSLAVE:
+		typ = SLAVE
+	case wire.IpTypeSLAVE_LITE:
+		typ = SLAVE_LITE
+	case wire.IpTypeSLAVE_STREAM:
+		typ = SLAVE_STREAM
+	case wire.IpTypeMASTER:
+		typ = MASTER
+	case wire.IpTypeMASTER_LITE:
+		typ = MASTER_LITE
+	case wire.IpTypeMASTER_STREAM:
+		typ = MASTER_STREAM
+	}
+
+	var impl IpImplementation
+	switch ii.Implementation() {
+	case wire.ImplementationTypeSOFTWARE:
+		impl = SOFTWARE
+	case wire.ImplementationTypeHARDWARE:
+		impl = HARDWARE
+	}
+	return &IpInfo{string(ii.Name()), ii.Address(), ii.Size(), ii.FirstInterrupt(), ii.NumInterrupts(), typ, impl}, nil
+}
+
+func (c *client) ackIpInfo(id uint64) error {
+	builder := flatbuffers.NewBuilder(0)
+	wire.MessageStart(builder)
+	wire.MessageAddType(builder, wire.TypeIP_ACK)
+	wire.MessageAddIpId(builder, id)
+	builder.Finish(wire.MessageEnd(builder))
+	return c.writeMsg(builder.FinishedBytes())
+}
+
+func (c *client) ack() error {
+	builder := flatbuffers.NewBuilder(0)
+	wire.MessageStart(builder)
+	wire.MessageAddType(builder, wire.TypeACK)
+	builder.Finish(wire.MessageEnd(builder))
+	return c.writeMsg(builder.FinishedBytes())
+}
+
+func (c *client) sendError(err error) error {
+	builder := flatbuffers.NewBuilder(0)
+	msg := builder.CreateString(err.Error())
+	wire.MessageStart(builder)
+	wire.MessageAddType(builder, wire.TypeIP_ACK)
+	wire.MessageAddErrorMessage(builder, msg)
+	builder.Finish(wire.MessageEnd(builder))
+	return c.writeMsg(builder.FinishedBytes())
+}
+
+func (c *client) commit(clients []SystemInfo, ips []*IpInfo) error {
+	// Acknowledge the commit message that ended the handshake
+	if err := c.ack(); err != nil {
+		return err
+	}
+
+	// Send the info about all clients
+	for _, cl := range clients {
+		builder := flatbuffers.NewBuilder(0)
+		name := builder.CreateString(cl.Name)
+		sysName := builder.CreateString(cl.SystemName)
+		hName := builder.CreateString(cl.Hostname)
+
+		wire.SystemInfoStart(builder)
+		wire.SystemInfoAddName(builder, name)
+		wire.SystemInfoAddSystemName(builder, sysName)
+		wire.SystemInfoAddHostname(builder, hName)
+		wire.SystemInfoAddPid(builder, cl.Pid)
+		si := wire.SystemInfoEnd(builder)
+
+		wire.MessageStart(builder)
+		wire.MessageAddType(builder, wire.TypeSYSTEM_INFO)
+		wire.MessageAddSystemInfo(builder, si)
+		builder.Finish(wire.MessageEnd(builder))
+
+		rsp := builder.FinishedBytes()
+		if err := c.writeMsg(rsp); err != nil {
+			return err
+		}
+	}
+
+	// Acknowledge the list of clients
+	if err := c.ack(); err != nil {
+		return err
+	}
+
+	// Send the full IP list
+	for _, ip := range ips {
+		builder := flatbuffers.NewBuilder(0)
+		name := builder.CreateString(ip.Name)
+
+		var typ wire.IpType
+		switch ip.Type {
+		case SLAVE:
+			typ = wire.IpTypeSLAVE
+		case SLAVE_LITE:
+			typ = wire.IpTypeSLAVE_LITE
+		case SLAVE_STREAM:
+			typ = wire.IpTypeSLAVE_STREAM
+		case MASTER:
+			typ = wire.IpTypeMASTER
+		case MASTER_LITE:
+			typ = wire.IpTypeMASTER_LITE
+		case MASTER_STREAM:
+			typ = wire.IpTypeMASTER_STREAM
+		}
+
+		var impl wire.ImplementationType
+		switch ip.Implementation {
+		case SOFTWARE:
+			impl = wire.ImplementationTypeSOFTWARE
+		case HARDWARE:
+			impl = wire.ImplementationTypeHARDWARE
+		}
+
+		wire.IpInfoStart(builder)
+		wire.IpInfoAddName(builder, name)
+		wire.IpInfoAddAddress(builder, ip.Address)
+		wire.IpInfoAddSize(builder, ip.Size)
+		wire.IpInfoAddFirstInterrupt(builder, ip.FirstInterrupt)
+		wire.IpInfoAddNumInterrupts(builder, ip.NumInterrupts)
+		wire.IpInfoAddType(builder, typ)
+		wire.IpInfoAddImplementation(builder, impl)
+		ipInfo := wire.SystemInfoEnd(builder)
+
+		wire.MessageStart(builder)
+		wire.MessageAddType(builder, wire.TypeIP_INFO)
+		wire.MessageAddIpInfo(builder, ipInfo)
+		builder.Finish(wire.MessageEnd(builder))
+
+		rsp := builder.FinishedBytes()
+		if err := c.writeMsg(rsp); err != nil {
+			return err
+		}
+	}
+
+	// Acknowledge the IP list
+	return c.ack()
+}
+
+func (c *client) writer() {
+	c.wg.Done()
+}
+
+func (c *client) reader() {
+	c.wg.Done()
+}
+
+func (c *client) close() {
+}
+
+func newClient(conn net.Conn, wg *sync.WaitGroup) *client {
+	c := new(client)
+	c.conn = conn
+	c.wg = wg
+	c.SystemInfo.Name = "unknown"
+	return c
+}

--- a/src/router/sw_axi/data.go
+++ b/src/router/sw_axi/data.go
@@ -1,0 +1,58 @@
+//------------------------------------------------------------------------------
+// Copyright (C) 2020 Daedalean AG
+//
+// This file is part of SW-AXI.
+//
+// SW-AXI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SW-AXI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with SW-AXI.  If not, see <https://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+//go:generate go run golang.org/x/tools/cmd/stringer -type IpType data.go
+//go:generate go run golang.org/x/tools/cmd/stringer -type IpImplementation data.go
+
+package sw_axi
+
+type IpType int
+
+const (
+	SLAVE IpType = iota
+	SLAVE_LITE
+	SLAVE_STREAM
+	MASTER
+	MASTER_LITE
+	MASTER_STREAM
+)
+
+type IpImplementation int
+
+const (
+	SOFTWARE IpImplementation = iota
+	HARDWARE
+)
+
+type SystemInfo struct {
+	Name       string
+	SystemName string
+	Hostname   string
+	Pid        uint64
+}
+
+type IpInfo struct {
+	Name           string
+	Address        uint64
+	Size           uint64
+	FirstInterrupt uint16
+	NumInterrupts  uint16
+	Type           IpType
+	Implementation IpImplementation
+}

--- a/src/router/sw_axi/router.go
+++ b/src/router/sw_axi/router.go
@@ -1,0 +1,133 @@
+//------------------------------------------------------------------------------
+// Copyright (C) 2020 Daedalean AG
+//
+// This file is part of SW-AXI.
+//
+// SW-AXI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SW-AXI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with SW-AXI.  If not, see <https://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+package sw_axi
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync"
+)
+
+type Router struct {
+	uri        string
+	numClients int
+	clients    []*client
+	ipCount    uint64
+	ips        map[uint64]*IpInfo
+}
+
+func NewRouter(uri string, numClients int) (*Router, error) {
+	if !strings.HasPrefix(uri, "unix://") {
+		return nil, fmt.Errorf("Only unix:// protocol is supported")
+	}
+
+	if numClients <= 0 {
+		return nil, fmt.Errorf("You'd probably really like to have at least some clients")
+	}
+
+	router := Router{}
+	router.uri = uri
+	router.numClients = numClients
+	router.ips = make(map[uint64]*IpInfo)
+	return &router, nil
+}
+
+func (r *Router) allocateIp(ip *IpInfo) (uint64, error) {
+	id := r.ipCount
+	r.ipCount++
+	r.ips[ip.Address] = ip
+	return id, nil
+}
+
+func (r *Router) Run() error {
+	if err := os.RemoveAll(r.uri[7:]); err != nil {
+		return fmt.Errorf("Can't remove the socket file: %s", err)
+	}
+
+	l, err := net.Listen("unix", r.uri[7:])
+	if err != nil {
+		return fmt.Errorf("Can't listen at %s: %s", r.uri, err)
+	}
+	defer l.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(r.numClients * 2)
+
+	for i := 0; i < r.numClients; i++ {
+		conn, err := l.Accept()
+		if err != nil {
+			return fmt.Errorf("Can't accept a client connection: %s", err)
+		}
+		ch := newClient(conn, &wg)
+		r.clients = append(r.clients, ch)
+		defer ch.close()
+	}
+
+	clInfo := []SystemInfo{}
+	for _, ch := range r.clients {
+		if err := ch.shakeHands(); err != nil {
+			return fmt.Errorf("Can't shake hands with client %s: %s", ch.SystemInfo.Name, err)
+		}
+
+		for {
+			ipInfo, err := ch.receiveIpInfo()
+			if err != nil {
+				return fmt.Errorf("Can't receive IP info from client %s: %s", ch.SystemInfo.Name, err)
+			}
+			if ipInfo == nil {
+				break
+			}
+
+			id, err := r.allocateIp(ipInfo)
+			if err != nil {
+				if err := ch.sendError(err); err != nil {
+					return fmt.Errorf("Can't receive IP info from client %s: %s", ch.SystemInfo.Name, err)
+				}
+			} else {
+				if err := ch.ackIpInfo(id); err != nil {
+					return fmt.Errorf("Can't receive IP info from client %s: %s", ch.SystemInfo.Name, err)
+				}
+			}
+		}
+		clInfo = append(clInfo, ch.SystemInfo)
+	}
+
+	ips := []*IpInfo{}
+	for _, ip := range r.ips {
+		ips = append(ips, ip)
+	}
+
+	for _, ch := range r.clients {
+		if err := ch.commit(clInfo, ips); err != nil {
+			return fmt.Errorf("Can't shake hands with client %s: %s", ch.SystemInfo.Name, err)
+		}
+	}
+
+	for _, ch := range r.clients {
+		go ch.writer()
+		go ch.reader()
+	}
+
+	wg.Wait()
+
+	return nil
+}

--- a/tests/00-version/testbench.cc
+++ b/tests/00-version/testbench.cc
@@ -5,20 +5,19 @@
 int main(int argc, char **argv) {
     using namespace sw_axi;
 
-    Bridge bridge;
+    Bridge bridge("00-version");
 
     if (bridge.connect() != 0) {
-        std::cerr << "Unable to connect to the simulation system" << std::endl;
+        std::cerr << "Unable to connect to the router" << std::endl;
         return 1;
     }
 
-    std::cerr << "Connected simulation system" << std::endl;
-    const SystemInfo *info = bridge.getRemoteSystemInfo();
-    std::cerr << "Name:     " << info->name << std::endl;
-    std::cerr << "Pid:      " << info->pid << std::endl;
-    std::cerr << "URI:      " << info->uri << std::endl;
-    std::cerr << "Hostname: " << info->hostname << std::endl;
-
+    std::cerr << "Connected to the router:" << std::endl;
+    const SystemInfo *rInfo = bridge.getRouterInfo();
+    std::cerr << "Name:        " << rInfo->name << std::endl;
+    std::cerr << "System Name: " << rInfo->systemName << std::endl;
+    std::cerr << "Pid:         " << rInfo->pid << std::endl;
+    std::cerr << "Hostname:    " << rInfo->hostname << std::endl;
     std::cerr << "Disconnecting" << std::endl;
     bridge.disconnect();
 


### PR DESCRIPTION
This CL implements a transaction router in Go. The C++ client has already been updated to use it. The next CL will factor out the connection functionality from the C++ client into a form that can be connected to the SystemVerilog DPI interface.

This CL also addresses some @Richard-Gordon comments in the previous PR. The reminder will be addressed in the subsequent one.