### PR TITLE
Factor out the networking functionality

### DIFF
--- a/src/common/Data.hh
+++ b/src/common/Data.hh
@@ -1,0 +1,88 @@
+//------------------------------------------------------------------------------
+// Copyright (C) 2020 Daedalean AG
+//
+// This file is part of SW-AXI.
+//
+// SW-AXI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SW-AXI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with SW-AXI.  If not, see <https://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace sw_axi {
+/**
+ * Properties of a connected system
+ */
+struct SystemInfo {
+    std::string name;
+    std::string systemName;
+    uint64_t pid;
+    std::string hostname;
+};
+
+/**
+ * Type of the IP registered IP
+ */
+enum class IpType { SLAVE, SLAVE_LITE, SLAVE_STREAM, MASTER, MASTER_LITE, MASTER_STREAM };
+
+/**
+ * Implementation type of the registered IP
+ */
+enum class IpImplementation { SOFTWARE, HARDWARE };
+
+/**
+ * Information about an IP block
+ */
+struct IpConfig {
+    std::string name;
+    uint64_t address = 0;  //!< Address of the slave
+    uint64_t size = 0;  //!< Size of the address space allocated to the slave
+    uint16_t firstInterrupt = 0;  //!< Number of the first interrupt allocated to the slave
+    uint16_t numInterrupts = 0;  //!< Number of interrupts allocated to the slave
+    IpType type = IpType::SLAVE;
+    IpImplementation implementation = IpImplementation::SOFTWARE;
+};
+
+/**
+ * A generic status indicator for operations
+ */
+class Status {
+public:
+    Status() {}
+    Status(uint32_t code, const std::string &msg) : msg(msg), code(code) {}
+
+    bool isOk() const {
+        return code == 0;
+    }
+
+    bool isError() const {
+        return code != 0;
+    }
+
+    const std::string &getMessage() const {
+        return msg;
+    }
+
+    uint32_t getCode() const {
+        return code;
+    }
+
+private:
+    uint32_t code = 0;
+    std::string msg;
+};
+
+}  // namespace sw_axi

--- a/src/common/RouterClient.cc
+++ b/src/common/RouterClient.cc
@@ -1,0 +1,336 @@
+//------------------------------------------------------------------------------
+// Copyright (C) 2020 Daedalean AG
+//
+// This file is part of SW-AXI.
+//
+// SW-AXI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SW-AXI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with SW-AXI.  If not, see <https://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+#include "RouterClient.hh"
+#include "IpcStructs_generated.h"
+#include "Utils.hh"
+
+#include <cstring>
+#include <errno.h>
+#include <sstream>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+namespace sw_axi {
+
+std::pair<SystemInfo *, Status> RouterClient::connect(const std::string &uri, const std::string &name) {
+    if (state != State::DISCONNECTED) {
+        Status st = Status(1, "The bridge needs to be disconnected for the connect operation to proceed");
+        return std::make_pair(nullptr, st);
+    }
+
+    if (uri.length() < 8 || uri.find("unix://") != 0) {
+        Status st = Status(1, "Can only communicate over UNIX domain sockets:" + uri);
+        return std::make_pair(nullptr, st);
+    }
+    std::string path = uri.substr(7);
+
+    sockaddr_un addr;
+    if (path.length() > sizeof(addr.sun_path) - 1) {
+        std::make_pair(nullptr, Status(1, "Path too long: " + path));
+    }
+
+    sock = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (sock == -1) {
+        Status st = Status(1, std::string("Unable to create a UNIX socket: ") + strerror(errno));
+        return std::make_pair(nullptr, st);
+    }
+
+    memset(&addr, 0, sizeof(sockaddr_un));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+
+    if (::connect(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(sockaddr_un)) == -1) {
+        disconnect();
+        Status st = Status(1, std::string("Unable to connect to the UNIX socket ") + path + ": " + strerror(errno));
+        return std::make_pair(nullptr, st);
+    }
+
+    connectedUri = uri;
+
+    std::ostringstream o;
+    utsname sysInfo;
+    uname(&sysInfo);
+    o << sysInfo.sysname << " C++";
+
+    flatbuffers::FlatBufferBuilder builder(1024);
+    auto bName = builder.CreateString(name);
+    auto sysName = builder.CreateString(o.str());
+    auto hName = builder.CreateString(sysInfo.nodename);
+    sw_axi::wire::SystemInfoBuilder siBuilder(builder);
+    siBuilder.add_name(bName);
+    siBuilder.add_systemName(sysName);
+    siBuilder.add_pid(getpid());
+    siBuilder.add_hostname(hName);
+    auto si = siBuilder.Finish();
+
+    sw_axi::wire::MessageBuilder msgBuilder(builder);
+    msgBuilder.add_type(sw_axi::wire::Type_SYSTEM_INFO);
+    msgBuilder.add_systemInfo(si);
+    builder.Finish(msgBuilder.Finish());
+
+    if (sw_axi::writeToSocket(sock, builder.GetBufferPointer(), builder.GetSize()) == -1) {
+        disconnect();
+        Status st = Status(1, std::string("Error while sending the system info: ") + strerror(errno));
+        return std::make_pair(nullptr, st);
+    }
+
+    std::vector<uint8_t> data;
+    if (readFromSocket(sock, data) == -1) {
+        disconnect();
+        Status st = Status(1, std::string("Error while receiving the router's system info:") + strerror(errno));
+        return std::make_pair(nullptr, st);
+    }
+    auto msg = wire::GetMessage(data.data());
+
+    if (msg->type() != wire::Type_SYSTEM_INFO) {
+        disconnect();
+        Status st = Status(1, "Received an unexpected message from the router: " + std::to_string(int(msg->type())));
+        return std::make_pair(nullptr, st);
+    }
+
+    SystemInfo *routerInfo = new SystemInfo();
+    routerInfo->name = msg->systemInfo()->name()->str();
+    routerInfo->systemName = msg->systemInfo()->systemName()->str();
+    routerInfo->pid = msg->systemInfo()->pid();
+    routerInfo->hostname = msg->systemInfo()->hostname()->str();
+    state = State::CONNECTED;
+
+    return std::make_pair(routerInfo, Status());
+}
+
+std::pair<uint64_t, Status> RouterClient::registerSlave(const IpConfig &config) {
+    if (state != State::CONNECTED) {
+        Status st = Status(1, "Can register slaves only in CONNECTED mode");
+        return std::make_pair(0, st);
+    }
+
+    flatbuffers::FlatBufferBuilder builder(1024);
+    auto fbName = builder.CreateString(config.name);
+    sw_axi::wire::IpInfoBuilder ipBuilder(builder);
+    ipBuilder.add_name(fbName);
+    ipBuilder.add_address(config.address);
+    ipBuilder.add_size(config.size);
+    ipBuilder.add_implementation(wire::ImplementationType_SOFTWARE);
+
+    switch (config.type) {
+    case IpType::SLAVE_LITE:
+        ipBuilder.add_type(wire::IpType_SLAVE_LITE);
+        break;
+    default:
+        Status st = Status(1, "Unknown slave type for slave: " + std::to_string(int(config.type)));
+        return std::make_pair(0, st);
+    }
+    auto ip = ipBuilder.Finish();
+
+    sw_axi::wire::MessageBuilder msgBuilder(builder);
+    msgBuilder.add_type(sw_axi::wire::Type_IP_INFO);
+    msgBuilder.add_ipInfo(ip);
+    builder.Finish(msgBuilder.Finish());
+
+    if (sw_axi::writeToSocket(sock, builder.GetBufferPointer(), builder.GetSize()) == -1) {
+        disconnect();
+        Status st = Status(1, std::string("Error while sending the IP_INFO message to router: ") + strerror(errno));
+        return std::make_pair(0, st);
+    }
+
+    std::vector<uint8_t> data;
+    if (readFromSocket(sock, data) == -1) {
+        disconnect();
+        Status st = Status(1, std::string("Error while receiving response to IP registration ") + strerror(errno));
+        return std::make_pair(0, st);
+    }
+
+    auto msg = wire::GetMessage(data.data());
+    if (msg->type() == wire::Type_ERROR) {
+        std::ostringstream o;
+        o << "Cannot register IP " << config.name << ": " << msg->errorMessage()->str();
+        disconnect();
+        return std::make_pair(0, Status(1, o.str()));
+    }
+
+    if (msg->type() != wire::Type_IP_ACK) {
+        std::ostringstream o;
+        o << "Got an unexpected response while registering IP " << config.name << ": " << msg->type();
+        disconnect();
+        return std::make_pair(0, Status(1, o.str()));
+    }
+
+    return std::make_pair(msg->ipId(), Status());
+}
+
+Status RouterClient::commitIp() {
+    if (state != State::CONNECTED) {
+        return Status(1, "Can commit slaves only in CONNECTED mode");
+    }
+
+    flatbuffers::FlatBufferBuilder builder(1024);
+    sw_axi::wire::MessageBuilder msgBuilder(builder);
+    msgBuilder.add_type(sw_axi::wire::Type_COMMIT);
+    builder.Finish(msgBuilder.Finish());
+
+    if (sw_axi::writeToSocket(sock, builder.GetBufferPointer(), builder.GetSize()) == -1) {
+        disconnect();
+        return Status(1, std::string("Error while sending the COMMIT message: ") + strerror(errno));
+    }
+
+    std::vector<uint8_t> data;
+    if (readFromSocket(sock, data) == -1) {
+        disconnect();
+        return Status(1, std::string("Error while receiving commit acknowledgement: ") + strerror(errno));
+    }
+
+    auto msg = wire::GetMessage(data.data());
+    if (msg->type() == wire::Type_ERROR) {
+        std::ostringstream o;
+        o << "Cannot register IP: " << msg->errorMessage()->str();
+        disconnect();
+        return Status(1, o.str());
+    }
+
+    if (msg->type() != wire::Type_ACK) {
+        std::ostringstream o;
+        o << "Got an unexpected response while committing IP: " << msg->type();
+        disconnect();
+        return Status(1, o.str());
+    }
+
+    state = State::COMMITTED;
+
+    return Status();
+}
+
+std::pair<SystemInfo *, Status> RouterClient::retrievePeerInfo() {
+    if (state != State::COMMITTED) {
+        Status st = Status(1, "The bridge needs to be COMMITTED in order to start");
+        return std::make_pair(nullptr, st);
+    }
+
+    std::vector<uint8_t> data;
+    const wire::Message *msg;
+
+    if (readFromSocket(sock, data) == -1) {
+        disconnect();
+        Status st = Status(1, std::string("Error while receiving the peer info: ") + strerror(errno));
+        return std::make_pair(nullptr, st);
+    }
+    msg = wire::GetMessage(data.data());
+
+    if (msg->type() == wire::Type_SYSTEM_INFO) {
+        SystemInfo *si = new SystemInfo();
+        si->name = msg->systemInfo()->name()->str();
+        si->systemName = msg->systemInfo()->systemName()->str();
+        si->pid = msg->systemInfo()->pid();
+        si->hostname = msg->systemInfo()->hostname()->str();
+        return std::make_pair(si, Status());
+    }
+
+    if (msg->type() == wire::Type_ERROR) {
+        std::ostringstream o;
+        o << "Error while receiving the peer list: " << msg->errorMessage()->str();
+        disconnect();
+        return std::make_pair(nullptr, Status(1, o.str()));
+    }
+
+    if (msg->type() != wire::Type_ACK) {
+        std::ostringstream o;
+        o << "Got an unexpected response while receiving peer list: " << msg->type();
+        disconnect();
+        return std::make_pair(nullptr, Status(1, o.str()));
+    }
+
+    state = State::PEER_INFO_RECEIVED;
+
+    return std::make_pair(nullptr, Status());
+}
+
+std::pair<IpConfig *, Status> RouterClient::retrieveIpConfig() {
+    if (state != State::PEER_INFO_RECEIVED) {
+        Status st = Status(1, "The client needs to receive all the peer info before receiving IP info");
+        return std::make_pair(nullptr, st);
+    }
+
+    std::vector<uint8_t> data;
+    const wire::Message *msg;
+
+    if (readFromSocket(sock, data) == -1) {
+        disconnect();
+        Status st = Status(1, std::string("Error while receiving the peer info: ") + strerror(errno));
+        return std::make_pair(nullptr, st);
+    }
+    msg = wire::GetMessage(data.data());
+
+    if (msg->type() == wire::Type_IP_INFO) {
+        IpConfig *ip = new IpConfig();
+        ip->name = msg->ipInfo()->name()->str();
+        ip->address = msg->ipInfo()->address();
+        ip->size = msg->ipInfo()->size();
+        ip->firstInterrupt = msg->ipInfo()->firstInterrupt();
+        ip->numInterrupts = msg->ipInfo()->numInterrupts();
+
+        switch (msg->ipInfo()->type()) {
+        case wire::IpType_SLAVE_LITE:
+            ip->type = IpType::SLAVE_LITE;
+            break;
+        default:
+            Status st = Status(1, "Received a slave of unknown type: " + std::to_string(int(msg->ipInfo()->type())));
+            return std::make_pair(nullptr, st);
+        }
+
+        ip->implementation = msg->ipInfo()->implementation() == wire::ImplementationType_SOFTWARE ?
+                IpImplementation::SOFTWARE :
+                IpImplementation::HARDWARE;
+
+        return std::make_pair(ip, Status());
+    }
+
+    if (msg->type() == wire::Type_ERROR) {
+        std::ostringstream o;
+        o << "Error while receiving the IP list: " << msg->errorMessage()->str();
+        disconnect();
+        return std::make_pair(nullptr, Status(1, o.str()));
+    }
+
+    if (msg->type() != wire::Type_ACK) {
+        std::ostringstream o;
+        o << "Got an unexpected response while receiving IP list: " << msg->type();
+        disconnect();
+        return std::make_pair(nullptr, Status(1, o.str()));
+    }
+
+    state = State::STARTED;
+
+    return std::make_pair(nullptr, Status());
+}
+
+void RouterClient::disconnect() {
+    if (sock == -1) {
+        return;
+    }
+
+    close(sock);
+    state = State::DISCONNECTED;
+    connectedUri = "";
+    sock = -1;
+}
+
+}  // namespace sw_axi

--- a/src/common/RouterClient.hh
+++ b/src/common/RouterClient.hh
@@ -1,0 +1,106 @@
+//------------------------------------------------------------------------------
+// Copyright (C) 2020 Daedalean AG
+//
+// This file is part of SW-AXI.
+//
+// SW-AXI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// SW-AXI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with SW-AXI.  If not, see <https://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+#pragma once
+
+#include "Data.hh"
+
+#include <cstdint>
+#include <utility>
+
+namespace sw_axi {
+
+class RouterClient {
+public:
+    /**
+     * Valid states of the client
+     */
+    enum class State {
+        DISCONNECTED,
+        CONNECTED,
+        COMMITTED,
+        PEER_INFO_RECEIVED,
+        STARTED,
+    };
+
+    /**
+     * Connect to the SystemVerilog simulator
+     *
+     * @param uri  an URI pointing to a rendez-vous point with the simulator; currently only UNIX domain sockets are
+     *             supported
+     * @param name name of the client
+     *
+     * @return     a system info-status pair; the system info pointer is null on failure; the user is responsible
+     *             for freeing the systeminfo object
+     */
+    std::pair<SystemInfo *, Status> connect(const std::string &uri, const std::string &name);
+
+    /**
+     * Register a software slave with the given parameters. The ownership of the slave object stays with the user.
+     *
+     * @return a slave id-status pair; the ID is invalid if the status indicates failure
+     */
+    std::pair<uint64_t, Status> registerSlave(const IpConfig &config);
+
+    /**
+     * Confirm that all IP has been registered.
+     *
+     * Calling this method will make the subsequent calls to `registerSlave` fail.
+     */
+    Status commitIp();
+
+    /**
+     * Retrieve the system information of a peer
+     *
+     * @return a system info-status pair; the user takes the ownership of the system info object; the system info
+     *         pointer is null on failure; if there is no failure and the system info pointer is null then the
+     *         peer info list is finished
+     */
+    std::pair<SystemInfo *, Status> retrievePeerInfo();
+
+    /**
+     * Retrieve the information about all the IP registered with the router
+     *
+     * @return a IP config-status pair; the user takes the ownership of the IP config object; the IP config
+     *         pointer is null on failure; if there is no failure and the IP config pointer is null then the
+     *         IP list is finished
+     */
+    std::pair<IpConfig *, Status> retrieveIpConfig();
+
+    /**
+     * Disconnect from server
+     *
+     * It is safe to call this method multiple times.
+     */
+    void disconnect();
+
+    /**
+     * Get the current state of the client
+     */
+    State getState() const {
+        return state;
+    }
+
+private:
+    State state = State::DISCONNECTED;
+    std::string connectedUri;
+    int sock = -1;
+};
+
+}  // namespace sw_axi

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -9,10 +9,10 @@ cpp: libsw-axi.so
 IpcStructs_generated.h: ../common/IpcStructs.fbs
 > flatc --cpp $^
 
-libsw-axi.so: SwAxi.cc SwAxi.hh ../common/Utils.hh ../common/Utils.cc IpcStructs_generated.h
+libsw-axi.so: SwAxi.cc SwAxi.hh ../common/Utils.hh ../common/Utils.cc IpcStructs_generated.h ../common/Data.hh
 > g++ -fPIC SwAxi.cc ../common/Utils.cc -shared -o libsw-axi.so -DVERBOSE
 
-format: SwAxi.cc SwAxi.hh ../common/Utils.hh ../common/Utils.cc
+format: SwAxi.cc SwAxi.hh ../common/Utils.hh ../common/Utils.cc ../common/Data.hh
 > @$(code-format)
 
 clean:

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -6,15 +6,15 @@ include $(TOP_DIR)/scripts/common.mk
 
 cpp: libsw-axi.so
 
-IpcStructs_generated.h: ../common/IpcStructs.fbs
-> flatc --cpp $^
+../common/IpcStructs_generated.h: ../common/IpcStructs.fbs
+> (cd ../common && flatc --cpp `basename $^`)
 
-libsw-axi.so: SwAxi.cc SwAxi.hh ../common/Utils.hh ../common/Utils.cc IpcStructs_generated.h ../common/Data.hh
-> g++ -fPIC SwAxi.cc ../common/Utils.cc -shared -o libsw-axi.so -DVERBOSE
+libsw-axi.so: SwAxi.cc SwAxi.hh ../common/Utils.hh ../common/Utils.cc ../common/IpcStructs_generated.h ../common/Data.hh ../common/RouterClient.cc ../common/RouterClient.hh
+> g++ -fPIC SwAxi.cc ../common/Utils.cc ../common/RouterClient.cc -shared -o libsw-axi.so -DVERBOSE
 
-format: SwAxi.cc SwAxi.hh ../common/Utils.hh ../common/Utils.cc ../common/Data.hh
+format: SwAxi.cc SwAxi.hh ../common/Utils.hh ../common/Utils.cc ../common/Data.hh ../common/RouterClient.hh ../common/RouterClient.cc
 > @$(code-format)
 
 clean:
 > rm -rf libsw-axi.so
-> rm -rf IpcStructs_generated.h
+> rm -rf ../common/IpcStructs_generated.h

--- a/src/lib/SwAxi.hh
+++ b/src/lib/SwAxi.hh
@@ -61,6 +61,8 @@ public:
     virtual int handleRead(Buffer *buffer) = 0;
 };
 
+class RouterClient;
+
 /**
  * Bridge is the software entry point of the infrastructure.
  *
@@ -70,7 +72,8 @@ public:
  */
 class Bridge {
 public:
-    Bridge(const std::string &name = "unnamed") : name(name) {}
+    Bridge(const std::string &name = "unnamed");
+    ~Bridge();
 
     /**
      * Connect to the router
@@ -119,21 +122,12 @@ public:
     Status enumeratePeers(std::vector<SystemInfo> &si);
 
     /**
-     * Disconnect from the simulator.
+     * Disconnect from the router.
      */
     void disconnect();
 
 private:
-    enum class State {
-        DISCONNECTED,
-        CONNECTED,
-        COMMITTED,
-        STARTED,
-    };
-
-    State state = State::DISCONNECTED;
-    std::string connectedUri;
-    int sock = -1;
+    RouterClient *client;
     std::unique_ptr<SystemInfo> routerInfo;
     std::vector<SystemInfo> peers;
     std::vector<IpConfig> ipBlocks;

--- a/src/lib/SwAxi.hh
+++ b/src/lib/SwAxi.hh
@@ -19,46 +19,16 @@
 
 #pragma once
 
+#include "../common/Data.hh"
+
 #include <cstdint>
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace sw_axi {
-
-/**
- * Properties of a connected system
- */
-struct SystemInfo {
-    std::string name;
-    std::string systemName;
-    uint64_t pid;
-    std::string hostname;
-};
-
-/**
- * Type of the IP registered IP
- */
-enum class IpType { SLAVE, SLAVE_LITE, SLAVE_STREAM, MASTER, MASTER_LITE, MASTER_STREAM };
-
-/**
- * Implementation type of the registered IP
- */
-enum class IpImplementation { SOFTWARE, HARDWARE };
-
-/**
- * Information about an IP block
- */
-struct IpConfig {
-    std::string name;
-    uint64_t address = 0;  //!< Address of the slave
-    uint64_t size = 0;  //!< Size of the address space allocated to the slave
-    uint16_t firstInterrupt = 0;  //!< Number of the first interrupt allocated to the slave
-    uint16_t numInterrupts = 0;  //!< Number of interrupts allocated to the slave
-    IpType type = IpType::SLAVE;
-    IpImplementation implementation = IpImplementation::SOFTWARE;
-};
 
 /**
  * Bus transaction data
@@ -103,14 +73,12 @@ public:
     Bridge(const std::string &name = "unnamed") : name(name) {}
 
     /**
-     * Connect to the SystemVerilog simulator
+     * Connect to the router
      *
-     * @param uri an URI pointing to a rendez-vous point with the simulator; currently only UNIX domain sockets are
+     * @param uri an URI pointing to a rendez-vous point with the router; currently only UNIX domain sockets are
      *            supported
-     *
-     * @return 0 on success; -1 on failure
      */
-    int connect(std::string uri = "unix:///tmp/sw-axi");
+    Status connect(std::string uri = "unix:///tmp/sw-axi");
 
     /**
      * Retrieve the information about the router
@@ -121,44 +89,34 @@ public:
 
     /**
      * Register a software slave with the given parameters. The bridge takes the ownership of thw slave object.
-     *
-     * @return 0 on success; -1 on failure
      */
-    int registerSlave(Slave *slave, const IpConfig &config);
+    Status registerSlave(Slave *slave, const IpConfig &config);
 
     /**
      * Confirm that all IP has been registered.
      *
      * Calling this method will make the subsequent calls to `registerSlave` fail.
-     *
-     * @return 0 on success; -1 on failure
      */
-    int commitIp();
+    Status commitIp();
 
     /**
      * Start the bridge and make it handle the transaction traffic.
-     *
-     * @return 0 on success; -1 on failure
      */
-    int start();
+    Status start();
 
     /**
      * Enumerate the available IP blocks
      *
      * @param ip reference to a vector to be filled with the IP information
-     *
-     * @return 0 on success; -1 on failure
      */
-    int enumerateIp(std::vector<IpConfig> &ip);
+    Status enumerateIp(std::vector<IpConfig> &ip);
 
     /**
      * Enumerate the connected peers
      *
      * @param peers reference to a vector to be filled with peer information
-     *
-     * @return 0 on success; -1 on failure
      */
-    int enumeratePeers(std::vector<SystemInfo> &si);
+    Status enumeratePeers(std::vector<SystemInfo> &si);
 
     /**
      * Disconnect from the simulator.

--- a/tests/00-version/testbench.cc
+++ b/tests/00-version/testbench.cc
@@ -7,8 +7,9 @@ int main(int argc, char **argv) {
 
     Bridge bridge("00-version");
 
-    if (bridge.connect() != 0) {
-        std::cerr << "Unable to connect to the router" << std::endl;
+    Status st = bridge.connect();
+    if (st.isError()) {
+        std::cerr << "Unable to connect to the router: " << st.getMessage() << std::endl;
         return 1;
     }
 

--- a/tests/01-handshake/testbench.cc
+++ b/tests/01-handshake/testbench.cc
@@ -19,8 +19,9 @@ int main(int argc, char **argv) {
 
     Bridge bridge("01-handshake-cpp");
 
-    if (bridge.connect() != 0) {
-        std::cerr << "Unable to connect to the router" << std::endl;
+    Status st = bridge.connect();
+    if (st.isError()) {
+        std::cerr << "Unable to connect to the router: " << st.getMessage() << std::endl;
         return 1;
     }
 
@@ -42,24 +43,28 @@ int main(int argc, char **argv) {
             .type = IpType::SLAVE_LITE,
             .implementation = IpImplementation::SOFTWARE};
 
-    if (bridge.registerSlave(ram, ramConfig) != 0) {
-        std::cerr << "Unable to register the Soft-RAM slave" << std::endl;
+    st = bridge.registerSlave(ram, ramConfig);
+    if (st.isError()) {
+        std::cerr << "Unable to register the Soft-RAM slave: " << st.getMessage() << std::endl;
         return 1;
     }
 
-    if (bridge.commitIp() != 0) {
-        std::cerr << "Unable to commit the IP" << std::endl;
+    st = bridge.commitIp();
+    if (st.isError()) {
+        std::cerr << "Unable to commit the IP: " << st.getMessage() << std::endl;
         return 1;
     }
 
-    if (bridge.start() != 0) {
-        std::cerr << "Unable to start the bridge" << std::endl;
+    st = bridge.start();
+    if (st.isError()) {
+        std::cerr << "Unable to start the bridge: " << st.getMessage() << std::endl;
         return 1;
     }
 
     std::vector<SystemInfo> peers;
-    if (bridge.enumeratePeers(peers) != 0) {
-        std::cerr << "Unable to enumerate peers" << std::endl;
+    st = bridge.enumeratePeers(peers);
+    if (st.isError()) {
+        std::cerr << "Unable to enumerate peers: " << st.getMessage() << std::endl;
         return 1;
     }
 
@@ -72,8 +77,9 @@ int main(int argc, char **argv) {
     std::cerr << std::endl;
 
     std::vector<IpConfig> ipBlocks;
-    if (bridge.enumerateIp(ipBlocks) != 0) {
-        std::cerr << "Unable to enumerate the IP" << std::endl;
+    st = bridge.enumerateIp(ipBlocks);
+    if (st.isError()) {
+        std::cerr << "Unable to enumerate the IP " << st.getMessage() << std::endl;
         return 1;
     }
 


### PR DESCRIPTION
This CL factors the networking functionality out of the `sw_axi::Bridge` class into a standalone `sw_axi::RouterClient` class. This is because that same networking functionality can be reused as-is in the SystemVerilog bindings which will be implemented in the next PR.

This CL also adds a more convenient status reporting.