### PR TITLE
Implement simulator connection and disconnection using the RouterClient API

### DIFF
--- a/src/common/RouterClient.cc
+++ b/src/common/RouterClient.cc
@@ -30,6 +30,9 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 
+#define STR0(x) #x
+#define STR1(x) STR0(x)
+
 namespace sw_axi {
 
 std::pair<SystemInfo *, Status> RouterClient::connect(const std::string &uri, const std::string &name) {
@@ -70,7 +73,12 @@ std::pair<SystemInfo *, Status> RouterClient::connect(const std::string &uri, co
     std::ostringstream o;
     utsname sysInfo;
     uname(&sysInfo);
+
+#ifndef SIM_ID
     o << sysInfo.sysname << " C++";
+#else
+    o << STR1(SIM_ID);
+#endif
 
     flatbuffers::FlatBufferBuilder builder(1024);
     auto bName = builder.CreateString(name);

--- a/src/lib/SwAxi.hh
+++ b/src/lib/SwAxi.hh
@@ -66,8 +66,8 @@ class RouterClient;
 /**
  * Bridge is the software entry point of the infrastructure.
  *
- * The bridge connects to a server, registers its IP components and receives the list of the components already
- * registered with the server. It can then send and receive requests directed at particular slaves as well as send and
+ * The bridge connects to a router, registers its IP components and receives the list of the components already
+ * registered with the router. It can then send and receive requests directed at particular slaves as well as send and
  * receive interrupt messages.
  */
 class Bridge {

--- a/src/sim/Makefile
+++ b/src/sim/Makefile
@@ -7,11 +7,11 @@ include $(TOP_DIR)/scripts/xilinx.mk
 
 sim: sw_axi.so
 
-IpcStructs_generated.h: ../common/IpcStructs.fbs
-> flatc --cpp $^
+../common/IpcStructs_generated.h: ../common/IpcStructs.fbs
+> (cd ../common && flatc --cpp `basename $^`)
 
-sw_axi.so: bridge.cc ../common/Utils.cc ../common/Utils.hh IpcStructs_generated.h
-> xsc bridge.cc ../common/Utils.cc -o sw_axi --cppversion 14 --gcc_compile_options '-DSIM_ID="`xsim --version`"'  --gcc_compile_options '-DVERBOSE'
+sw_axi.so: bridge.cc ../common/Utils.hh ../common/Utils.cc ../common/IpcStructs_generated.h ../common/Data.hh ../common/RouterClient.cc ../common/RouterClient.hh
+> xsc bridge.cc ../common/Utils.cc ../common/RouterClient.cc -o sw_axi --cppversion 14 --gcc_compile_options '-DSIM_ID="`xsim --version`"'  --gcc_compile_options '-DVERBOSE'
 
 format: bridge.sv bridge.cc ../common/Utils.hh ../common/Utils.cc axi4lite.sv axi4lite.sv interfaces.sv package.sv remote.sv utils.sv
 > @$(code-format)
@@ -19,4 +19,4 @@ format: bridge.sv bridge.cc ../common/Utils.hh ../common/Utils.cc axi4lite.sv ax
 clean:
 > @$(xsim-clean)
 > rm -rf sw_axi.so
-> rm -rf IpcStructs_generated.h
+> rm -rf ../common/IpcStructs_generated.h

--- a/src/sim/bridge.cc
+++ b/src/sim/bridge.cc
@@ -17,440 +17,108 @@
 // along with SW-AXI.  If not, see <https://www.gnu.org/licenses/>.
 //------------------------------------------------------------------------------
 
-#include "../common/Utils.hh"
-#include "IpcStructs_generated.h"
+#include "../common/RouterClient.hh"
 
-#include "svdpi.h"
-
-#include <cstring>
-#include <errno.h>
+#include <exception>
 #include <iostream>
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <sys/un.h>
-#include <unistd.h>
-#include <utility>
 
-#define STR0(x) #x
-#define STR1(x) STR0(x)
+using namespace sw_axi;
 
-#ifndef SIM_ID
-#define SIM_ID "unknown"
-#endif
-
-namespace {
-
-/**
- * A helper class for communicating IP information to SystemVerilog
- */
-struct IpInfo {
-    std::string name;
-    uint64_t startAddr = 0;
-    uint64_t endAddr = 0;
-    int type = 0;
-    int implementation = 0;
-};
-
-/**
- * Bridge is the SystemVerilog DPI counterpart of the `sw_axi::Bridge`.
- *
- * It implements the communication mechanism with the software side of the system.
- */
-class Bridge {
-public:
-    /**
-     * Create a server socket at the given randez-vous point and wait for the client to connect
-     *
-     * @param uri an URI pointing to the rendez-vous point with the software client; currently only UNIX domain sockets
-     *            are supported
-     *
-     * @return 0 on success; -1 on failure
-     */
-    int connect(const std::string &uri);
-
-    /**
-     * Send the info about the system to the client
-     *
-     * @return 0 on success; -1 on failure
-     */
-    int sendSystemInfo();
-
-    /**
-     * Send IP information to the client
-     *
-     * @return 0 on success; -1 on failure
-     */
-    int sendIpInfo(const std::string &name, int type, int implementation, uint64_t startAddr, uint64_t endAddr);
-
-    /**
-     * Receive the IP information from the client
-     *
-     * @return 0 on success; -1 on failure
-     */
-    std::pair<int, IpInfo *> receiveIpInfo();
-
-    /**
-     * Send and acknowledgement message
-     *
-     * @return 0 on success; -1 on failure
-     */
-    int acknowledge();
-
-    /**
-     * Send an error message
-     *
-     * @return 0 on success; -1 on failure
-     */
-    int reportError(const std::string msg);
-
-    /**
-     * Close the connection with the client and clean up the associated resources
-     */
-    void disconnect();
-
-    /**
-     * Wait for the client to disconnect and clean up the server-side resouces associated with the connection
-     */
-    void waitForDisconnect();
-
-private:
-    std::string connectedUri;
-    int sock = -1;
-};
-
-int Bridge::connect(const std::string &uri) {
-    LOG << "[SW-AXI] Creating an IPC server at: " << uri << std::endl;
-
-    if (uri.length() < 8 || uri.find("unix://") != 0) {
-        LOG << "[SW-AXI] Can only communicate over UNIX domain sockets " << uri << std::endl;
-        return -1;
-    }
-    std::string path = uri.substr(7);
-
-    if (sock != -1) {
-        LOG << "[SW-AXI] The bridge is already connected to " << connectedUri << std::endl;
-        return -1;
-    }
-
-    sockaddr_un addr;
-    if (path.length() > sizeof(addr.sun_path) - 1) {
-        LOG << "[SW-AXI] Path too long: " << path << std::endl;
-        return -1;
-    }
-
-    if (remove(path.c_str()) == -1 && errno != ENOENT) {
-        LOG << "[SW-AXI] Unable to remove: " << path << std::endl;
-        return -1;
-    }
-
-    sock = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (sock == -1) {
-        LOG << "[SW-AXI] Unable to create a UNIX socket: " << strerror(errno) << std::endl;
-        return -1;
-    }
-
-    memset(&addr, 0, sizeof(sockaddr_un));
-    addr.sun_family = AF_UNIX;
-    strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
-
-    if (bind(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(sockaddr_un)) == -1) {
-        LOG << "[SW-AXI] Unable to bind the socket: " << strerror(errno) << std::endl;
-        disconnect();
-        return -1;
-    }
-
-    if (listen(sock, 1) == -1) {
-        LOG << "[SW-AXI] Unable to listen for incomming connections: " << strerror(errno) << std::endl;
-        disconnect();
-        return -1;
-    }
-
-    int connSock = accept(sock, nullptr, nullptr);
-    if (connSock == -1) {
-        LOG << "[SW-AXI] Unable to accept a connection: " << strerror(errno) << std::endl;
-        disconnect();
-        return -1;
-    }
-
-    sock = connSock;
-    connectedUri = uri;
-
-    std::vector<uint8_t> data;
-    if (sw_axi::readFromSocket(sock, data) == -1) {
-        LOG << "[SW-AXI] Error while receiving the system info" << std::endl;
-        disconnect();
-        return -1;
-    }
-
-    auto msg = sw_axi::wire::GetMessage(data.data());
-    if (msg->type() != sw_axi::wire::Type_SYSTEM_INFO) {
-        LOG << "[SW-AXI] Received an unexpected message from the simulator" << std::endl;
-        disconnect();
-        return -1;
-    }
-
-    LOG << "[SW-AXI] Client " << msg->systemInfo()->name()->str() << " connected to: " << uri << std::endl;
-    return 0;
+extern "C" void *sw_axi_client_new() {
+    return new RouterClient();
 }
 
-int Bridge::sendSystemInfo() {
-    char hn[256];
-    hn[0] = 0;
-    gethostname(hn, 256);
-
-    flatbuffers::FlatBufferBuilder builder(1024);
-    auto name = builder.CreateString(std::string(STR1(SIM_ID)));
-    auto uri = builder.CreateString(connectedUri);
-    auto hostname = builder.CreateString(hn);
-    sw_axi::wire::SystemInfoBuilder siBuilder(builder);
-    siBuilder.add_name(name);
-    siBuilder.add_pid(getpid());
-    siBuilder.add_uri(uri);
-    siBuilder.add_hostname(hostname);
-    auto si = siBuilder.Finish();
-
-    sw_axi::wire::MessageBuilder msgBuilder(builder);
-    msgBuilder.add_type(sw_axi::wire::Type_SYSTEM_INFO);
-    msgBuilder.add_systemInfo(si);
-    builder.Finish(msgBuilder.Finish());
-
-    if (sw_axi::writeToSocket(sock, builder.GetBufferPointer(), builder.GetSize()) == -1) {
-        return -1;
-    }
-    return 0;
+extern "C" void sw_axi_client_delete(void *client) {
+    RouterClient *c = reinterpret_cast<RouterClient *>(client);
+    delete c;
 }
 
-int Bridge::sendIpInfo(const std::string &name, int type, int implementation, uint64_t startAddr, uint64_t endAddr) {
-    if (sock == -1) {
-        LOG << "[SW-AXI] Client not connected" << std::endl;
-        return -1;
+extern "C" void
+sw_axi_client_connect(void *client, void **status, void **systemInfo, const char *uri, const char *name) {
+    if (!client || !status || !systemInfo) {
+        std::cerr << "Either of client, status, or systemInfo pointers is null" << std::endl;
+        std::terminate();
     }
-
-    LOG << "[SW-AXI] Registering slave " << name << " " << startAddr << " " << endAddr << std::endl;
-    flatbuffers::FlatBufferBuilder builder(1024);
-    auto fbName = builder.CreateString(name);
-    sw_axi::wire::IpInfoBuilder ipBuilder(builder);
-    ipBuilder.add_name(fbName);
-    ipBuilder.add_startAddr(startAddr);
-    ipBuilder.add_endAddr(endAddr);
-
-    switch (type) {
-    case 1:
-        ipBuilder.add_type(sw_axi::wire::IpType_SLAVE_LITE);
-        break;
-    default:
-        LOG << "[SW-AXI] Unknown slave type for slave " << name << ": " << type << std::endl;
-        return -1;
-    }
-
-    auto impl =
-            implementation == 0 ? sw_axi::wire::ImplementationType_SOFTWARE : sw_axi::wire::ImplementationType_HARDWARE;
-    ipBuilder.add_implementation(impl);
-    auto ip = ipBuilder.Finish();
-
-    sw_axi::wire::MessageBuilder msgBuilder(builder);
-    msgBuilder.add_type(sw_axi::wire::Type_IP_INFO);
-    msgBuilder.add_ipInfo(ip);
-    builder.Finish(msgBuilder.Finish());
-
-    if (sw_axi::writeToSocket(sock, builder.GetBufferPointer(), builder.GetSize()) == -1) {
-        LOG << "[SW-AXI] Error while sending the SIMULATOR_INFO message to software" << std::endl;
-        disconnect();
-        return -1;
-    }
-
-    return 0;
+    RouterClient *c = reinterpret_cast<RouterClient *>(client);
+    std::pair<SystemInfo *, Status> ret = c->connect(uri, name);
+    *systemInfo = ret.first;
+    *status = new Status(ret.second);
 }
 
-std::pair<int, IpInfo *> Bridge::receiveIpInfo() {
-    std::vector<uint8_t> data;
-    if (sw_axi::readFromSocket(sock, data) == -1) {
-        LOG << "[SW-AXI] Failed to get the IP Info from software" << std::endl;
-        disconnect();
-        return std::make_pair(-1, nullptr);
+extern "C" void sw_axi_client_disconnect(void *client) {
+    if (!client) {
+        std::cerr << "The client pointer is null" << std::endl;
+        std::terminate();
     }
-
-    auto msg = sw_axi::wire::GetMessage(data.data());
-    if (msg->type() == sw_axi::wire::Type_COMMIT) {
-        return std::make_pair(0, nullptr);
-    }
-
-    if (msg->type() != sw_axi::wire::Type_IP_INFO) {
-        LOG << "[SW-AXI] Got unexpected message from software, expected IP_INFO" << std::endl;
-        disconnect();
-        return std::make_pair(-1, nullptr);
-    }
-
-    IpInfo *info = new IpInfo();
-    info->name = msg->ipInfo()->name()->str();
-    info->startAddr = msg->ipInfo()->startAddr();
-    info->endAddr = msg->ipInfo()->endAddr();
-
-    switch (msg->ipInfo()->type()) {
-    case sw_axi::wire::IpType_SLAVE_LITE:
-        info->type = 1;
-        break;
-    default:
-        delete info;
-        LOG << "[SW-AXI] Invalid IP type: " << msg->ipInfo()->type() << std::endl;
-        return std::make_pair(0, nullptr);
-    }
-    info->implementation = msg->ipInfo()->implementation() == sw_axi::wire::ImplementationType_SOFTWARE ? 0 : 1;
-    return std::make_pair(0, info);
+    RouterClient *c = reinterpret_cast<RouterClient *>(client);
+    c->disconnect();
 }
 
-int Bridge::acknowledge() {
-    flatbuffers::FlatBufferBuilder builder(1024);
-    sw_axi::wire::MessageBuilder msgBuilder(builder);
-    msgBuilder.add_type(sw_axi::wire::Type_ACK);
-    builder.Finish(msgBuilder.Finish());
-
-    if (sw_axi::writeToSocket(sock, builder.GetBufferPointer(), builder.GetSize()) == -1) {
-        LOG << "[SW-AXI] Error while sending an ACK message to the simulator" << std::endl;
-        disconnect();
-        return -1;
+extern "C" const char *sw_axi_status_get_msg(void *status) {
+    if (!status) {
+        std::cerr << "The status pointer is null" << std::endl;
+        std::terminate();
     }
 
-    return 0;
+    Status *st = reinterpret_cast<Status *>(status);
+    return st->getMessage().c_str();
 }
 
-int Bridge::reportError(const std::string errorMsg) {
-    flatbuffers::FlatBufferBuilder builder(1024);
-    auto errorMsgFb = builder.CreateString(errorMsg);
-    sw_axi::wire::MessageBuilder msgBuilder(builder);
-    msgBuilder.add_type(sw_axi::wire::Type_ERROR);
-    msgBuilder.add_errorMessage(errorMsgFb);
-    builder.Finish(msgBuilder.Finish());
-
-    if (sw_axi::writeToSocket(sock, builder.GetBufferPointer(), builder.GetSize()) == -1) {
-        LOG << "[SW-AXI] Error while sending an ERROR message to the simulator" << std::endl;
-        disconnect();
-        return -1;
+extern "C" unsigned int sw_axi_status_get_code(void *status) {
+    if (!status) {
+        std::cerr << "The status pointer is null" << std::endl;
+        std::terminate();
     }
 
-    return 0;
+    Status *st = reinterpret_cast<Status *>(status);
+    return st->getCode();
 }
 
-void Bridge::disconnect() {
-    if (sock != -1) {
-        close(sock);
-        sock = -1;
-    }
+extern "C" void sw_axi_status_delete(void *status) {
+    Status *st = reinterpret_cast<Status *>(status);
+    delete st;
 }
 
-void Bridge::waitForDisconnect() {
-    if (sock == -1) {
-        LOG << "[SW-AXI] Client not connected" << std::endl;
-        return;
-    }
-    LOG << "[SW-AXI] Waiting for the client to disconnect from: " << connectedUri << std::endl;
-
-    // TODO(lj): This is enough to track disconnection, to be replaced by a condition variable later
-    char buff;
-    read(sock, &buff, 1);
-    disconnect();
-
-    LOG << "[SW-AXI] Client disconnected from: " << connectedUri << std::endl;
-}
-}  // namespace
-
-extern "C" void *sw_axi_connect(const char *uri) {
-    Bridge *bridge = new Bridge;
-    if (bridge->connect(uri) != 0) {
-        return NULL;
+extern "C" const char *sw_axi_system_info_get_name(void *systemInfo) {
+    if (!systemInfo) {
+        std::cerr << "The systemInfo pointer is null" << std::endl;
+        std::terminate();
     }
 
-    if (bridge->sendSystemInfo() != 0) {
-        bridge->disconnect();
-        delete bridge;
-        return NULL;
+    SystemInfo *si = reinterpret_cast<SystemInfo *>(systemInfo);
+    return si->name.c_str();
+}
+
+extern "C" const char *sw_axi_system_info_get_system_name(void *systemInfo) {
+    if (!systemInfo) {
+        std::cerr << "The systemInfo pointer is null" << std::endl;
+        std::terminate();
     }
 
-    return reinterpret_cast<void *>(bridge);
+    SystemInfo *si = reinterpret_cast<SystemInfo *>(systemInfo);
+    return si->systemName.c_str();
 }
-
-extern "C" void sw_axi_disconnect(void *bridgeHandle) {
-    if (!bridgeHandle) {
-        return;
+extern "C" const unsigned long long sw_axi_system_info_get_pid(void *systemInfo) {
+    if (!systemInfo) {
+        std::cerr << "The systemInfo pointer is null" << std::endl;
+        std::terminate();
     }
 
-    Bridge *bridge = reinterpret_cast<Bridge *>(bridgeHandle);
-    bridge->waitForDisconnect();
-    delete bridge;
+    SystemInfo *si = reinterpret_cast<SystemInfo *>(systemInfo);
+    return si->pid;
 }
 
-extern "C" int sw_axi_ip_info_receive(void *bridgeHandle, void **ip) {
-    if (!bridgeHandle || !ip) {
-        return -1;
+extern "C" const char *sw_axi_system_info_get_hostname(void *systemInfo) {
+    if (!systemInfo) {
+        std::cerr << "The systemInfo pointer is null" << std::endl;
+        std::terminate();
     }
 
-    Bridge *bridge = reinterpret_cast<Bridge *>(bridgeHandle);
-    auto si = bridge->receiveIpInfo();
-    if (si.first == -1) {
-        return -1;
-    }
-
-    *ip = si.second;
-    return 0;
+    SystemInfo *si = reinterpret_cast<SystemInfo *>(systemInfo);
+    return si->hostname.c_str();
 }
 
-extern "C" const char *sw_axi_ip_info_get_name(void *ip) {
-    IpInfo *ipInfo = reinterpret_cast<IpInfo *>(ip);
-    return ipInfo->name.c_str();
-}
-
-extern "C" void sw_axi_ip_info_get_addr(void *ip, unsigned long long *start, unsigned long long *end) {
-    IpInfo *ipInfo = reinterpret_cast<IpInfo *>(ip);
-    *start = ipInfo->startAddr;
-    *end = ipInfo->endAddr;
-}
-
-extern "C" int sw_axi_ip_info_get_type(void *ip) {
-    IpInfo *ipInfo = reinterpret_cast<IpInfo *>(ip);
-    return ipInfo->type;
-}
-
-extern "C" int sw_axi_ip_info_get_implementation(void *ip) {
-    IpInfo *ipInfo = reinterpret_cast<IpInfo *>(ip);
-    return ipInfo->implementation;
-}
-
-extern "C" void sw_axi_ip_info_free(void *ip) {
-    IpInfo *ipInfo = reinterpret_cast<IpInfo *>(ip);
-    delete ipInfo;
-}
-
-extern "C" int sw_axi_acknowledge(void *bridgeHandle) {
-    if (!bridgeHandle) {
-        return -1;
-    }
-
-    Bridge *bridge = reinterpret_cast<Bridge *>(bridgeHandle);
-    return bridge->acknowledge();
-}
-
-extern "C" int sw_axi_report_error(void *bridgeHandle, const char *msg) {
-    if (!bridgeHandle) {
-        return -1;
-    }
-
-    Bridge *bridge = reinterpret_cast<Bridge *>(bridgeHandle);
-    return bridge->reportError(msg);
-}
-
-extern "C" int sw_axi_ip_info_send(
-        void *bridgeHandle,
-        const char *name,
-        int type,
-        int implementation,
-        unsigned long long startAddr,
-        unsigned long long endAddr) {
-    if (!bridgeHandle) {
-        return -1;
-    }
-
-    Bridge *bridge = reinterpret_cast<Bridge *>(bridgeHandle);
-    return bridge->sendIpInfo(name, type, implementation, startAddr, endAddr);
+extern "C" void sw_axi_system_info_delete(void *systemInfo) {
+    SystemInfo *si = reinterpret_cast<SystemInfo *>(systemInfo);
+    delete si;
 }

--- a/src/sim/bridge.sv
+++ b/src/sim/bridge.sv
@@ -17,129 +17,53 @@
 // along with SW-AXI.  If not, see <https://www.gnu.org/licenses/>.
 //------------------------------------------------------------------------------
 
-import "DPI-C" function chandle sw_axi_connect(string uri);
-import "DPI-C" function void sw_axi_disconnect(chandle bridgeHandle);
+import "DPI-C" function chandle sw_axi_client_new();
+import "DPI-C" function void sw_axi_client_delete(chandle client);
 
-import "DPI-C" function int sw_axi_ip_info_receive(chandle bridgeHandle, output chandle ip);
-import "DPI-C" function string sw_axi_ip_info_get_name(chandle ip);
-import "DPI-C" function void sw_axi_ip_info_get_addr(chandle ip, output longint unsigned startAddr, output longint unsigned endAddr);
-import "DPI-C" function int sw_axi_ip_info_get_type(chandle ip);
-import "DPI-C" function int sw_axi_ip_info_get_implementation(chandle ip);
-import "DPI-C" function void sw_axi_ip_info_free(chandle ip);
-
-import "DPI-C" function int sw_axi_acknowledge(chandle bridgeHandle);
-import "DPI-C" function int sw_axi_report_error(chandle bridgeHandle, string msg);
-
-import "DPI-C" function int sw_axi_ip_info_send(chandle bridgeHandle, string name, int ipType, int ipImplementation, longint unsigned startAddr, longint unsigned endAddr);
+import "DPI-C" function void sw_axi_client_connect(chandle client, output chandle status, output chandle systemInfo, input string uri, input string name);
+import "DPI-C" function void sw_axi_client_disconnect(chandle client);
 
 /**
- * A connection point to the software-size of the system
+  * Bridge is the software entry point of the infrastructure.
+ *
+ * The bridge connects to a router, registers its IP components and receives the list of the components already
+ * registered with the router. It can then send and receive requests directed at particular slaves as well as send and
+ * receive interrupt messages.
  */
 class Bridge;
-  chandle bridgeHandle;
-  bit started;
-  SlaveMap slaves;
+  chandle client;
+  string name;
+  SystemInfo routerInfo;
 
-  function new();
-    bridgeHandle = null;
-    started = 'b0;
-    slaves = new();
+  function new(string name_ = "unnamed");
+    client = null;
+    name = name_;
   endfunction
 
   /**
-   * Create a server socket at the rendez-vous point and wait for the client to connect. Then receive the list
-   * all the IP blocks implemented on the remote side.
+   * Connect to the router
    *
-   * @return 0 on success; -1 on failure
+   * @param uri an URI pointing to a rendez-vous point with the router; currently only UNIX domain sockets are
+   *            supported
    */
-  function int connect (string uri = "unix:///tmp/sw-axi");
-    bridgeHandle = sw_axi_connect(uri);
-    if (bridgeHandle == null) return 'b1;
+  function Status connect (string uri = "unix:///tmp/sw-axi");
+    chandle st;
+    chandle si;
+    client = sw_axi_client_new();
+    sw_axi_client_connect(client, st, si, uri, name);
 
-
-    while (1) begin
-      chandle ipInfo;
-      Range addr;
-      string name;
-      IpType ipType;
-      IpImplementation ipImplementation;
-      SlaveRemote slave;
-
-      if (sw_axi_ip_info_receive(bridgeHandle, ipInfo) != 0) begin
-        return -1;
-      end
-
-      // We received a commit that we still have to acknowledge after registering all of our own IP
-      if (ipInfo == null) begin
-        break;
-      end
-
-      sw_axi_ip_info_get_addr(ipInfo, addr.rStart, addr.rEnd);
-      name = sw_axi_ip_info_get_name(ipInfo);
-      ipType = convertIpType(sw_axi_ip_info_get_type(ipInfo));
-      ipImplementation = convertIpImplementation(sw_axi_ip_info_get_implementation(ipInfo));
-      slave = new(name, addr, ipType, ipImplementation);
-      sw_axi_ip_info_free(ipInfo);
-
-      if (slaves.registerSlave(slave) != 0) begin
-        if (sw_axi_report_error(bridgeHandle, "Unable to register IP due to address space conflict") != 0) begin
-          return -1;
-        end
-      end else begin
-        if (sw_axi_acknowledge(bridgeHandle) != 0) begin
-          return -1;
-        end
-      end
+    if (si != null) begin
+      routerInfo = convertSystemInfo(si);
     end
-    return 0;
+    return convertStatus(st);
   endfunction
 
   /**
-   * Wait for the client to disconnect and clean up the server resource associated with the connection
-   *
-   * TODO(lj): This should probably be a task
+   * Disconnect from the router
    */
-  function void waitForDisconnect();
-    sw_axi_disconnect(bridgeHandle);
+  function void disconnect();
+    sw_axi_client_disconnect(client);
+    sw_axi_client_delete(client);
+    client = null;
   endfunction
-
-  /**
-   * Register a slave with the bridge
-   *
-   * @return 0 on success; -1 on failure
-   */
-  function int registerSlave(Slave slave);
-    return slaves.registerSlave(slave);
-  endfunction
-
-  /**
-   * Send the complete list of the available IP to the client and start handling data transactions.
-   *
-   * @return 0 on success; -1 on failure
-   */
-  function int start();
-    Slave slaveArr[$];
-    integer unsigned i;
-
-    // Acknowledget the COMMIT from client
-    if (sw_axi_acknowledge(bridgeHandle) != 0) begin
-      return -1;
-    end
-
-    slaves.getSlaves(slaveArr);
-    for (i = 0; i < slaveArr.size(); i++) begin
-      Slave s = slaveArr[i];
-      bit ret = sw_axi_ip_info_send(bridgeHandle, s.getName(), s.getType(), s.getImplementation(), s.getAddressSpace().rStart, s.getAddressSpace().rEnd);
-      if (ret == -1) begin
-        return -1;
-      end
-    end
-
-    if (sw_axi_acknowledge(bridgeHandle) == -1) begin
-      return -1;
-    end
-
-    return -1;
-  endfunction
-
 endclass

--- a/src/sim/package.sv
+++ b/src/sim/package.sv
@@ -20,10 +20,10 @@
 package sw_axi;
 
   `include "utils.sv"
-  `include "interfaces.sv"
+  //  `include "interfaces.sv"
   `include "bridge.sv"
-  `include "axi4lite.sv"
-  `include "remote.sv"
+  //  `include "axi4lite.sv"
+  //  `include "remote.sv"
 
 endpackage
 

--- a/tests/00-version/testbench.cc
+++ b/tests/00-version/testbench.cc
@@ -5,7 +5,7 @@
 int main(int argc, char **argv) {
     using namespace sw_axi;
 
-    Bridge bridge("00-version");
+    Bridge bridge("00-version-cpp");
 
     Status st = bridge.connect();
     if (st.isError()) {

--- a/tests/00-version/testbench.sv
+++ b/tests/00-version/testbench.sv
@@ -1,11 +1,24 @@
 
 module testbench;
-  sw_axi::Bridge bridge = new();
+  sw_axi::Bridge bridge = new("00-version-sv");
   initial begin
-    if (bridge.connect() == 0) begin
-      $display("connected!");
+    sw_axi::Status st;
+    sw_axi::SystemInfo rInfo;
+
+    st = bridge.connect();
+    if (st.isError()) begin
+      $error("Unable to connect to the router: %s", st.message);
+      $finish();
     end
 
-    bridge.waitForDisconnect();
+    $display("Connected to the router:");
+    rInfo = bridge.routerInfo;
+    $display("Name:        %s", rInfo.name);
+    $display("System Name: %s", rInfo.systemName);
+    $display("Pid:         %d", rInfo.pid);
+    $display("Hostname:    %s", rInfo.hostname);
+    $display("Disconnecting");
+
+    bridge.disconnect();
   end
 endmodule


### PR DESCRIPTION
This CL uses the new RouterClient API to connect the SystemVerilog simulator to the router instead of having the simulator itself act as a server/router. Doing things this way makes it possible to connect multiple simulators, possibly at multiple machines to multiple software clients and have the transaction routing between all of them. The reminder of the functionality will follow in a subsequent PR.